### PR TITLE
Fix minor typo in client closure helper

### DIFF
--- a/src/main/java/com/rpuch/pulsar/reactor/impl/PulsarClientClosure.java
+++ b/src/main/java/com/rpuch/pulsar/reactor/impl/PulsarClientClosure.java
@@ -26,11 +26,11 @@ import java.util.function.Supplier;
  */
 public class PulsarClientClosure {
     public static Mono<Void> closeQuietly(Supplier<? extends CompletableFuture<Void>> closerSupplier) {
-        return fromWithoutWithoutCancellationPropagation(closerSupplier)
+        return fromWithoutCancellationPropagation(closerSupplier)
                 .onErrorResume(AlreadyClosedException.class, ex -> Mono.empty());
     }
 
-    private static Mono<Void> fromWithoutWithoutCancellationPropagation(
+    private static Mono<Void> fromWithoutCancellationPropagation(
             Supplier<? extends CompletableFuture<Void>> closerSupplier) {
         return Mono.fromFuture(closerSupplier);
     }


### PR DESCRIPTION
## Summary
- rename method `fromWithoutWithoutCancellationPropagation` to `fromWithoutCancellationPropagation`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fca7d34e48325923d48c95b567d46