### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pulsar Reactive Client #
 
-This is a wrapper around asyncronous facilities provided by the official
+This is a wrapper around asynchronous facilities provided by the official
 [Apache Pulsar Java Client](https://github.com/apache/pulsar/tree/master/pulsar-client) using
 [Reactor Core](https://github.com/reactor/reactor-core) interfaces.
 


### PR DESCRIPTION
## Summary
- fix asynchronous typo in README

## Testing
- `grep -n asynchronous README.md`

------
https://chatgpt.com/codex/tasks/task_e_685fd1da2dcc83259797c2d4f48037f4