### PR TITLE
Fix test method typos

### DIFF
--- a/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImplTest.java
+++ b/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImplTest.java
@@ -56,7 +56,7 @@ class ReactiveConsumerBuilderImplTest {
     private Consumer<String> coreConsumer;
 
     @Test
-    void forOneReturnsResullOfInternalTransformation() {
+    void forOneReturnsResultOfInternalTransformation() {
         when(coreBuilder.subscribeAsync()).thenReturn(completedFuture(coreConsumer));
         when(coreConsumer.closeAsync()).thenReturn(completedFuture(null));
 
@@ -99,7 +99,7 @@ class ReactiveConsumerBuilderImplTest {
     }
 
     @Test
-    void forManyReturnsResullOfInternalTransformation() {
+    void forManyReturnsResultOfInternalTransformation() {
         when(coreBuilder.subscribeAsync()).thenReturn(completedFuture(coreConsumer));
         when(coreConsumer.closeAsync()).thenReturn(completedFuture(null));
 

--- a/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveProducerBuilderImplTest.java
+++ b/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveProducerBuilderImplTest.java
@@ -61,7 +61,7 @@ class ReactiveProducerBuilderImplTest {
     private Producer<String> coreProducer;
 
     @Test
-    void forOneReturnsResullOfInternalTransformation() {
+    void forOneReturnsResultOfInternalTransformation() {
         when(coreBuilder.createAsync()).thenReturn(completedFuture(coreProducer));
         when(coreProducer.closeAsync()).thenReturn(completedFuture(null));
 
@@ -104,7 +104,7 @@ class ReactiveProducerBuilderImplTest {
     }
 
     @Test
-    void forManyReturnsResullOfInternalTransformation() {
+    void forManyReturnsResultOfInternalTransformation() {
         when(coreBuilder.createAsync()).thenReturn(completedFuture(coreProducer));
         when(coreProducer.closeAsync()).thenReturn(completedFuture(null));
 

--- a/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveProducerImplTest.java
+++ b/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveProducerImplTest.java
@@ -112,7 +112,7 @@ class ReactiveProducerImplTest {
     }
 
     @Test
-    void newMessageWithScheaReturnsABuilderCooperatingWithCoreProducer() {
+    void newMessageWithSchemaReturnsABuilderCooperatingWithCoreProducer() {
         when(coreProducer.newMessage(any(StringSchema.class))).thenReturn(messageBuilder);
 
         assertThat(reactiveProducer.newMessage(Schema.STRING), notNullValue());

--- a/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveReaderBuilderImplTest.java
+++ b/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveReaderBuilderImplTest.java
@@ -113,7 +113,7 @@ class ReactiveReaderBuilderImplTest {
     }
     
     @Test
-    void forOneReturnsResullOfInternalTransformation() {
+    void forOneReturnsResultOfInternalTransformation() {
         when(coreBuilder.createAsync()).thenReturn(completedFuture(coreReader));
         when(coreReader.closeAsync()).thenReturn(completedFuture(null));
 
@@ -156,7 +156,7 @@ class ReactiveReaderBuilderImplTest {
     }
 
     @Test
-    void forManyReturnsResullOfInternalTransformation() {
+    void forManyReturnsResultOfInternalTransformation() {
         when(coreBuilder.createAsync()).thenReturn(completedFuture(coreReader));
         when(coreReader.closeAsync()).thenReturn(completedFuture(null));
 


### PR DESCRIPTION
## Summary
- fix typos in test method names for consumer, producer, and reader builder tests
- fix schema typo in producer tests

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fd207de508325b79ef86b592e1f05