### PR TITLE
Fix typo in chunked message configuration

### DIFF
--- a/src/main/java/com/rpuch/pulsar/reactor/api/ReactiveConsumerBuilder.java
+++ b/src/main/java/com/rpuch/pulsar/reactor/api/ReactiveConsumerBuilder.java
@@ -584,20 +584,20 @@ public interface ReactiveConsumerBuilder<T> extends Cloneable {
      * Here, Messages M1-C1 and M1-C2 belong to original message M1, M2-C1 and M2-C2 messages belong to M2 message.
      * </pre>
      * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
-     * guarded by providing this @maxPendingChuckedMessage threshold. Once, consumer reaches this threshold, it drops
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once, consumer reaches this threshold, it drops
      * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
      * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
      *
      * @default 100
      *
-     * @param maxPendingChuckedMessage
+     * @param maxPendingChunkedMessage
      * @return
      */
-    ReactiveConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage);
+    ReactiveConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage);
 
     /**
      * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
-     * guarded by providing this @maxPendingChuckedMessage threshold. Once, consumer reaches this threshold, it drops
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once, consumer reaches this threshold, it drops
      * the outstanding unchunked-messages by silently acking if autoAckOldestChunkedMessageOnQueueFull is true else it
      * marks them for redelivery.
      *

--- a/src/main/java/com/rpuch/pulsar/reactor/api/ReactiveProducerBuilder.java
+++ b/src/main/java/com/rpuch/pulsar/reactor/api/ReactiveProducerBuilder.java
@@ -255,7 +255,7 @@ public interface ReactiveProducerBuilder<T> extends Cloneable {
      * so, consumer will not be able to consume and ack those messages. So, those messages can
      * be only discared by msg ttl) Or configure
      * {@link ReactiveConsumerBuilder#expireTimeOfIncompleteChunkedMessage()}
-     * 5. Consumer configuration: consumer should also configure receiverQueueSize and maxPendingChuckedMessage
+     * 5. Consumer configuration: consumer should also configure receiverQueueSize and maxPendingChunkedMessage
      * </pre>
      * @param enableChunking
      * @return

--- a/src/main/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImpl.java
+++ b/src/main/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImpl.java
@@ -317,8 +317,8 @@ public class ReactiveConsumerBuilderImpl<T> implements ReactiveConsumerBuilder<T
     }
 
     @Override
-    public ReactiveConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage) {
-        coreBuilder.maxPendingChuckedMessage(maxPendingChuckedMessage);
+    public ReactiveConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage) {
+        coreBuilder.maxPendingChunkedMessage(maxPendingChunkedMessage);
         return this;
     }
 

--- a/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImplTest.java
+++ b/src/test/java/com/rpuch/pulsar/reactor/impl/ReactiveConsumerBuilderImplTest.java
@@ -568,15 +568,15 @@ class ReactiveConsumerBuilderImplTest {
     }
 
     @Test
-    void setsMaxPendingChuckedMessageOnCoreBuilder() {
-        reactiveBuilder.maxPendingChuckedMessage(1);
+    void setsMaxPendingChunkedMessageOnCoreBuilder() {
+        reactiveBuilder.maxPendingChunkedMessage(1);
 
-        verify(coreBuilder).maxPendingChuckedMessage(1);
+        verify(coreBuilder).maxPendingChunkedMessage(1);
     }
 
     @Test
-    void maxPendingChuckedMessageReturnsSameBuilder() {
-        assertThat(reactiveBuilder.maxPendingChuckedMessage(1), sameInstance(reactiveBuilder));
+    void maxPendingChunkedMessageReturnsSameBuilder() {
+        assertThat(reactiveBuilder.maxPendingChunkedMessage(1), sameInstance(reactiveBuilder));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rename `maxPendingChuckedMessage` to `maxPendingChunkedMessage`
- adjust builder implementation and tests
- update related javadocs

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fd1b5064c8325bc8d3e318ea0762d